### PR TITLE
Switch benchmark example to RoBERTa

### DIFF
--- a/examples/tools/benchmark-pytorch/run.sh
+++ b/examples/tools/benchmark-pytorch/run.sh
@@ -6,11 +6,11 @@ set -e
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"
 
-# If ResNet50 hasn't been downloaded yet, download it.
-if ! [ -f ../common/resnet50-pytorch/resnet50.torchscript ]; then
-	../common/resnet50-pytorch/download-model.sh -o ../common/resnet50-pytorch/resnet50.torchscript
+# If RoBERTa hasn't been downloaded yet, download it.
+if ! [ -f ../common/roberta-pytorch/roberta.torchscript ]; then
+	../common/roberta-pytorch/download-model.sh -o ../common/roberta-pytorch/roberta.torchscript
 fi
 
 # Now for the easy part -- benchmarking ;)
 # PyTorch models require --input-data-schema to be specified.
-max benchmark --input-data-schema=../common/resnet50-pytorch/input-spec.yaml ../common/resnet50-pytorch/resnet50.torchscript
+max benchmark --input-data-schema=../common/roberta-pytorch/input-spec.yaml ../common/roberta-pytorch/roberta.torchscript

--- a/examples/tools/benchmark-tensorflow/run.sh
+++ b/examples/tools/benchmark-tensorflow/run.sh
@@ -6,10 +6,11 @@ set -e
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"
 
-# If ResNet50 hasn't been downloaded yet, download it.
-if ! [ -d ../common/resnet50-tensorflow/resnet50-savedmodel ]; then
-	../common/resnet50-tensorflow/download-model.sh -o ../common/resnet50-tensorflow/resnet50-savedmodel
+# If RoBERTa hasn't been downloaded yet, download it.
+if ! [ -d ../common/roberta-tensorflow/roberta-savedmodel ]; then
+	../common/roberta-tensorflow/download-model.sh -o ../common/roberta-tensorflow/roberta-savedmodel
 fi
 
 # Now for the easy part -- benchmarking ;)
-max benchmark ../common/resnet50-tensorflow/resnet50-savedmodel
+# Even though this is a TensorFlow model, we need --input-data-schema in order to override how the inputs are generated, since the inputs must have a fixed range and the model has dynamic input shapes.
+max benchmark  --input-data-schema=../common/roberta-tensorflow/input-spec.yaml ../common/roberta-tensorflow/roberta-savedmodel

--- a/examples/tools/common/roberta-pytorch/.gitignore
+++ b/examples/tools/common/roberta-pytorch/.gitignore
@@ -1,0 +1,2 @@
+*.bin
+*.torchscript

--- a/examples/tools/common/roberta-pytorch/download-model.py
+++ b/examples/tools/common/roberta-pytorch/download-model.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Download RoBERTa PyTorch model from HuggingFace."""
+
+import argparse
+import os
+import sys
+import tempfile
+import traceback
+import urllib.request
+
+
+INSTALL_PROSE = """Is it installed?
+
+If not, try:
+
+    python3 -m venv venv; source venv/bin/activate  # if you aren't already in a virtual environment
+    pip install torch
+
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="path to save TorchScript model to",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    if os.path.exists(args.output):
+        print(f"output {args.output!r} already exists")
+        return
+
+    print("Importing PyTorch...", flush=True)
+    try:
+        import torch
+    except ModuleNotFoundError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="torchimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            (
+                f"Torch module was not found.  {INSTALL_PROSE}"
+                f"Detailed error info in {log_file.name}"
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except ImportError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="torchimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            (
+                "PyTorch installation seems to be broken.\n"
+                "Make sure you can 'import torch' "
+                "from a Python prompt and try again.\n"
+                f"Detailed error info in {log_file.name}"
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Importing HuggingFace transformers...", flush=True)
+    try:
+        from transformers import RobertaForSequenceClassification
+    except ModuleNotFoundError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="hfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            (
+                "HuggingFace transformers module was not found. "
+                f" {INSTALL_PROSE}Detailed error info in {log_file.name}"
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except ImportError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="hfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            (
+                "HuggingFace transformers installation seems to be broken.\n"
+                "Make sure you can 'import transformers' "
+                "from a Python prompt and try again.\n"
+                f"Detailed error info in {log_file.name}"
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Getting pre-trained model...", flush=True)
+    model = RobertaForSequenceClassification.from_pretrained(
+        "cardiffnlp/twitter-roberta-base-emotion-multilabel-latest"
+    )
+    print("Tracing model...", flush=True)
+    traced_model = torch.jit.trace(
+        model,
+        [
+            torch.zeros(1, 128, dtype=torch.int64),
+            torch.ones(1, 128, dtype=torch.float32),
+            torch.zeros(1, 128, dtype=torch.int64),
+        ],
+        strict=False,
+    )
+    print("Saving TorchScript...", flush=True)
+    traced_model.save(args.output)
+    print("All done!", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tools/common/roberta-pytorch/download-model.sh
+++ b/examples/tools/common/roberta-pytorch/download-model.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Wrapper around download-model.py that sets up a temporary venv & installs
+# dependencies if needed.
+
+set -e
+
+script="$(dirname "$0")/download-model.py"
+
+# Check to see if PyTorch and HuggingFace Transformers are installed.
+if python3 -c 'import torch; import transformers' >& /dev/null; then
+	python3 "$script" "$@"
+else
+	# Required dependencies not installed -- set up a venv and install them
+	# in there, then run the script (cleaning up the venv afterwards).
+	venv_dir="$(mktemp -d)"
+	python3 -m venv "$venv_dir"
+	"$venv_dir/bin/pip" install -U setuptools pip wheel
+	"$venv_dir/bin/pip" install torch transformers
+	"$venv_dir/bin/python3" "$script" "$@"
+	rm -rf "$venv_dir"
+fi

--- a/examples/tools/common/roberta-pytorch/input-spec.yaml
+++ b/examples/tools/common/roberta-pytorch/input-spec.yaml
@@ -1,0 +1,16 @@
+inputs:
+  - input_name: input_ids
+    shape: 1x128xsi64
+    data:
+      random:
+        uniform:
+          min: 0
+          max: 50264
+  - input_name: token_type_ids
+    shape: 1x128xsi64
+    data:
+      constant: 0
+  - input_name: attention_mask
+    shape: 1x128xf32
+    data:
+      constant: 1

--- a/examples/tools/common/roberta-tensorflow/.gitignore
+++ b/examples/tools/common/roberta-tensorflow/.gitignore
@@ -1,0 +1,1 @@
+roberta-savedmodel/

--- a/examples/tools/common/roberta-tensorflow/download-model.py
+++ b/examples/tools/common/roberta-tensorflow/download-model.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Download RoBERTa TensorFlow model from HuggingFace."""
+
+import argparse
+import os
+import sys
+import tempfile
+import traceback
+
+
+INSTALL_PROSE = """Is it installed?
+
+If not, try:
+
+    python3 -m venv venv; source venv/bin/activate  # if you aren't already in a virtual environment
+    pip install tensorflow transformers
+
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="path to save TensorFlow SavedModel to",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    if os.path.exists(args.output):
+        print(f"output {args.output!r} already exists")
+        return
+
+    print("Importing TensorFlow...", flush=True)
+    try:
+        import tensorflow as tf
+    except ModuleNotFoundError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="tfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            f"TensorFlow module was not found.  {INSTALL_PROSE}"
+            f"Detailed error info in {log_file.name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except ImportError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="tfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            "TensorFlow installation seems to be broken.\n"
+            "Make sure you can 'import tensorflow' "
+            "from a Python prompt and try again.\n"
+            f"Detailed error info in {log_file.name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Importing HuggingFace transformers...", flush=True)
+    try:
+        from transformers import TFRobertaForSequenceClassification
+    except ModuleNotFoundError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="hfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            f"HuggingFace transformers module was not found.  {INSTALL_PROSE}"
+            f"Detailed error info in {log_file.name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except ImportError:
+        with tempfile.NamedTemporaryFile(
+            mode="w", prefix="hfimport", suffix=".log", delete=False
+        ) as log_file:
+            traceback.print_exc(file=log_file)
+        print(
+            "HuggingFace transformers installation seems to be broken.\n"
+            "Make sure you can 'import transformers' "
+            "from a Python prompt and try again.\n"
+            f"Detailed error info in {log_file.name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Getting pre-trained model...", flush=True)
+    model = TFRobertaForSequenceClassification.from_pretrained(
+        "cardiffnlp/twitter-roberta-base-emotion-multilabel-latest"
+    )
+    print("Saving TensorFlow SavedModel...", flush=True)
+    tf.saved_model.save(model, args.output)
+    print("All done!", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tools/common/roberta-tensorflow/download-model.sh
+++ b/examples/tools/common/roberta-tensorflow/download-model.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Wrapper around download-model.py that sets up a temporary venv & installs
+# dependencies if needed.
+
+set -e
+
+script="$(dirname "$0")/download-model.py"
+
+# Check to see if TensorFlow & HuggingFace Transformers are installed.
+if python3 -c 'import tensorflow; import transformers' >& /dev/null; then
+	python3 "$script" "$@"
+else
+	# Required dependencies not installed -- set up a venv and install them
+	# in there, then run the script (cleaning up the venv afterwards).
+	venv_dir="$(mktemp -d)"
+	python3 -m venv "$venv_dir"
+	"$venv_dir/bin/pip" install -U setuptools pip wheel
+	"$venv_dir/bin/pip" install tensorflow transformers
+	"$venv_dir/bin/python3" "$script" "$@"
+	rm -rf "$venv_dir"
+fi

--- a/examples/tools/common/roberta-tensorflow/input-spec.yaml
+++ b/examples/tools/common/roberta-tensorflow/input-spec.yaml
@@ -1,0 +1,16 @@
+inputs:
+  - input_name: input_ids
+    shape: 1x128xsi32
+    data:
+      random:
+        uniform:
+          min: 0
+          max: 50264
+  - input_name: token_type_ids
+    shape: 1x128xsi32
+    data:
+      constant: 0
+  - input_name: attention_mask
+    shape: 1x128xsi32
+    data:
+      constant: 1


### PR DESCRIPTION
ResNet-50 currently takes longer to compile than RoBERTa does.  Swap out the model to RoBERTa so the user spends less time waiting for model compilation.  We'd switch the visualize example too, but RoBERTa is a more complicated model that pushes the limits of Netron -- ResNet-50 is more reasonably sized and works better with Netron, even though it takes longer to compile in MAX.