### PR TITLE
Update setuptools before installing dependencies from requirements.txt

### DIFF
--- a/examples/inference/bert-c-tensorflow/README.md
+++ b/examples/inference/bert-c-tensorflow/README.md
@@ -6,7 +6,7 @@ This directory includes scripts used to run simple BERT inference via the MAX En
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 ```

--- a/examples/inference/bert-c-torchscript/README.md
+++ b/examples/inference/bert-c-torchscript/README.md
@@ -6,7 +6,7 @@ This directory includes scripts used to run simple BERT inference via the MAX En
 
 ```
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 ```

--- a/examples/inference/bert-python-torchscript/README.md
+++ b/examples/inference/bert-python-torchscript/README.md
@@ -7,7 +7,7 @@ Python API to predict the sentiment of the given text.
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 

--- a/examples/inference/resnet50-python-tensorflow/README.md
+++ b/examples/inference/resnet50-python-tensorflow/README.md
@@ -8,7 +8,7 @@ leatherback turtle as an example.
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 

--- a/examples/inference/roberta-python-tensorflow/README.md
+++ b/examples/inference/roberta-python-tensorflow/README.md
@@ -6,7 +6,7 @@ This directory includes scripts used to run simple RoBERTa inference via the MAX
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 

--- a/examples/inference/stablediffusion-mojo-tensorflow/README.md
+++ b/examples/inference/stablediffusion-mojo-tensorflow/README.md
@@ -10,7 +10,7 @@ Once you have the MAX AI engine installed, this example can be run with:
 
 ```
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 ```

--- a/examples/inference/stablediffusion-python-tensorflow/README.md
+++ b/examples/inference/stablediffusion-python-tensorflow/README.md
@@ -9,7 +9,7 @@ it via the MAX Python API.
 Once you have the MAX AI engine installed, this example can be run with:
 ```
 python3 -m venv venv && source venv/bin/activate
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt
 bash run.sh
 ```


### PR DESCRIPTION
It may throw an error on some OSes and architectures (Ubuntu 20 on Graviton) if there's an old `setuptools` installed. So we upgrade it before installing dependencies from `requirements.txt`.
The version range in `requirements.txt` is not enough because pip installs dependencies from `requirements.txt` all at once using older `setuptools`.
I'll keep the version range in `requirements.txt` as a "message" for users.