### PR TITLE
Make console ROOT universal

### DIFF
--- a/examples/console.py
+++ b/examples/console.py
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 import os
+from pathlib import Path
 import subprocess
 
 try:
@@ -24,7 +25,7 @@ except ImportError:
     from rich.console import Console
     from rich.table import Table
 
-ROOT = os.path.dirname(__file__)
+ROOT = Path(os.path.dirname(__file__))
 
 def list_repositories():
     repos = []


### PR DESCRIPTION
For python3.8, there seems to be a bug related `os.path.dirname(__file__)` returning empty string which using `pathlib.Path` fixes it.