### PR TITLE
Fix #18 cpuinfo not found crash

### DIFF
--- a/examples/performance-showcase/requirements.txt
+++ b/examples/performance-showcase/requirements.txt
@@ -1,3 +1,4 @@
 pillow
 tensorflow
 transformers
+py-cpuinfo

--- a/examples/performance-showcase/run.py
+++ b/examples/performance-showcase/run.py
@@ -51,7 +51,7 @@ try:
 
     info_message = "\n" + "-" * 40 + "System Info" + "-" * 40
     info_message += "\n"
-    info_message += "\n".join([ f"{labels[k]}: {cpu.get(k, "")}" for k in keys ]) 
+    info_message += "\n".join([ f'{labels[k]}: {cpu.get(k, "")}' for k in keys ]) 
 
     print(info_message)
 except:

--- a/examples/performance-showcase/run.py
+++ b/examples/performance-showcase/run.py
@@ -51,7 +51,7 @@ try:
 
     info_message = "\n" + "-" * 40 + "System Info" + "-" * 40
     info_message += "\n"
-    info_message += "\n".join([ f"{labels[k]}: {cpu[k]}" for k in keys ]) 
+    info_message += "\n".join([ f"{labels[k]}: {cpu.get(k, "")}" for k in keys ]) 
 
     print(info_message)
 except:

--- a/examples/performance-showcase/run.py
+++ b/examples/performance-showcase/run.py
@@ -41,10 +41,21 @@ commands = [
 
 shell(commands, print_progress=True, env={"TF_CPP_MIN_LOG_LEVEL": "9"})
 print("\nStarting inference throughput comparison")
-info_message = "-" * 40 + "System Info" + "-" * 40
-print(f"\n{info_message}\n")
-subprocess.run(["cpuinfo", "-g"])
-print("\n" + "-" * len(info_message))
+try:
+    import cpuinfo
+    
+    cpu = cpuinfo.get_cpu_info()
+
+    keys = ["brand_raw", "arch", "hz_advertised_friendly", "count"]
+    labels = {"brand_raw": "CPU", "arch": "Arch", "hz_advertised_friendly": "Clock speed", "count": "Cores"}
+
+    info_message = "\n" + "-" * 40 + "System Info" + "-" * 40
+    info_message += "\n"
+    info_message += "\n".join([ f"{labels[k]}: {cpu[k]}" for k in keys ]) 
+
+    print(info_message)
+except:
+    pass
 
 print("\nRunning with TensorFlow")
 shell([f"python3 run_tf.py {args.model}"], stdout=None)
@@ -71,6 +82,7 @@ if "pt" in results:
     print(
         f'Modular ({results["max"]:.2f} QPS) > PyTorch ({results["pt"]:.2f} QPS). {next(exclamations)} It\'s {results["max"]/results["pt"]:.2f}x faster!'
     )
-    print()
 else:
     pass
+
+print()


### PR DESCRIPTION
Relying on cpuinfo was an expedient but brittle approach to providing some system information along with the performance comparison printout. 

This PR fixes #18 by failing gracefully if the host os doesn't expose the basic information we want to present (instead of crashing). 