### PR TITLE
Add initial CODEOWNERS file to max repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,0 +1,5 @@
+# Codeowners for MAX repo.
+# Every line is a file pattern that is followed by one or more code owners.
+# Order is important; the last matching pattern takes the most precedence.
+
+* @modularml/max-code-reviewers


### PR DESCRIPTION
This PR introduces a `CODEOWNERS` file in the MAX repo. Modulers who are added to the `max-code-reviewers` team will be automatically subscribed to all code reviews made against this public repository. We can also adjust granularity wrt functional scope demonstrated in this repo in the future.