### PR TITLE
Move max.engine import order to top of source files

### DIFF
--- a/examples/inference/bert-python-torchscript/simple-inference.py
+++ b/examples/inference/bert-python-torchscript/simple-inference.py
@@ -11,12 +11,12 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from max import engine
+
 from argparse import ArgumentParser
 
 import torch
 from transformers import AutoTokenizer
-
-from max import engine
 
 # suppress extraneous logging
 import os

--- a/examples/inference/resnet50-python-tensorflow/simple-inference.py
+++ b/examples/inference/resnet50-python-tensorflow/simple-inference.py
@@ -13,6 +13,8 @@
 
 #!/usr/bin/env python3
 
+from max import engine
+
 import os
 
 # suppress extraneous logging
@@ -23,7 +25,6 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 import numpy as np
 
 from argparse import ArgumentParser
-from max import engine
 from PIL import Image
 from transformers import AutoImageProcessor, TFAutoModelForImageClassification
 

--- a/examples/inference/roberta-python-tensorflow/simple-inference.py
+++ b/examples/inference/roberta-python-tensorflow/simple-inference.py
@@ -13,6 +13,8 @@
 
 #!/usr/bin/env python3
 
+from max import engine
+
 import os
 
 # suppress extraneous logging
@@ -21,7 +23,6 @@ os.environ["TRANSFORMERS_VERBOSITY"] = "critical"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from argparse import ArgumentParser
-from max import engine
 from transformers import AutoTokenizer, TFRobertaForSequenceClassification
 
 DEFAULT_MODEL_DIR = "roberta"

--- a/examples/inference/stablediffusion-mojo-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-mojo-tensorflow/download-model.py
@@ -13,6 +13,8 @@
 
 #!/usr/bin/env python3
 
+from max import engine
+
 import logging
 import os
 from argparse import ArgumentParser
@@ -27,8 +29,6 @@ import tensorflow as tf
 # logging messages, so we have to setLevel here again to suppress them.
 logger = tf.get_logger()
 logger.setLevel(logging.ERROR)
-
-from max import engine
 
 
 DEFAULT_MODEL_DIR = "stable-diffusion"

--- a/examples/inference/stablediffusion-python-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-python-tensorflow/download-model.py
@@ -23,12 +23,13 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 import keras_cv
 import tensorflow as tf
 
-from max import engine
-
 # In TensorFlow 2.0, setting TF_CPP_MIN_LOG_LEVEL does not work for all
 # logging messages, so we have to setLevel here again to suppress them.
 logger = tf.get_logger()
 logger.setLevel(logging.ERROR)
+
+from max import engine
+
 
 DEFAULT_MODEL_DIR = "stable-diffusion"
 DESCRIPTION = "Download a Stable Diffusion model."

--- a/examples/inference/stablediffusion-python-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-python-tensorflow/download-model.py
@@ -13,6 +13,8 @@
 
 #!/usr/bin/env python3
 
+from max import engine
+
 import logging
 import os
 from argparse import ArgumentParser
@@ -27,9 +29,6 @@ import tensorflow as tf
 # logging messages, so we have to setLevel here again to suppress them.
 logger = tf.get_logger()
 logger.setLevel(logging.ERROR)
-
-from max import engine
-
 
 DEFAULT_MODEL_DIR = "stable-diffusion"
 DESCRIPTION = "Download a Stable Diffusion model."

--- a/examples/inference/stablediffusion-python-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-python-tensorflow/download-model.py
@@ -13,6 +13,8 @@
 
 #!/usr/bin/env python3
 
+from max import engine
+
 import logging
 import os
 from argparse import ArgumentParser

--- a/examples/inference/stablediffusion-python-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-python-tensorflow/download-model.py
@@ -13,8 +13,6 @@
 
 #!/usr/bin/env python3
 
-from max import engine
-
 import logging
 import os
 from argparse import ArgumentParser
@@ -24,6 +22,8 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 import keras_cv
 import tensorflow as tf
+
+from max import engine
 
 # In TensorFlow 2.0, setting TF_CPP_MIN_LOG_LEVEL does not work for all
 # logging messages, so we have to setLevel here again to suppress them.


### PR DESCRIPTION
We move max.engine imports to the top of each source file due to a documented [issue here](https://docs.beta.modular.com/engine/roadmap#pytorch-error-cannot-allocate-memory-in-static-tls-block)