### PR TITLE
Move max import statements up ahead of Keras

### DIFF
--- a/examples/inference/stablediffusion-python-tensorflow/text-to-image.py
+++ b/examples/inference/stablediffusion-python-tensorflow/text-to-image.py
@@ -18,6 +18,9 @@ import os
 # suppress extraneous logging
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
+from max.engine import InferenceSession
+from max.engine import Model
+
 import keras_cv
 import numpy as np
 
@@ -25,9 +28,6 @@ from argparse import ArgumentParser
 from constants import _ALPHAS_CUMPROD as ALPHAS
 from math import log, sqrt
 from PIL import Image
-
-from max.engine import InferenceSession
-from max.engine import Model
 
 DEFAULT_MODEL_DIR = "stable-diffusion"
 DESCRIPTION = "Generate an image based on the given prompt."


### PR DESCRIPTION
We have seen some TLS issues manifest when the Max engine is imported after KerasCV. While the root cause is under investigation, moving this import line should reduce errors in the common case of simply running our examples. 