### PR TITLE
Run black to fix file formatting and remove redundant max.engine import

### DIFF
--- a/examples/inference/bert-python-torchscript/triton-inference.py
+++ b/examples/inference/bert-python-torchscript/triton-inference.py
@@ -30,6 +30,7 @@ DEFAULT_MODEL_NAME = "bert"
 DESCRIPTION = "BERT model"
 HF_MODEL_NAME = "bert-base-uncased"
 
+
 def execute(triton_client, model_name, inputs):
     # Set the input data
     triton_inputs = [
@@ -99,7 +100,7 @@ def main():
 
     # Classify input statement
     outputs = execute(triton_client, args.model_name, inputs)
-    
+
     # Extract class prediction from output
     predicted_class_id = outputs.argmax(axis=-1)[0]
     sentiment_labels = {0: "Negative", 1: "Positive"}

--- a/examples/inference/resnet50-python-tensorflow/triton-inference.py
+++ b/examples/inference/resnet50-python-tensorflow/triton-inference.py
@@ -34,13 +34,15 @@ HF_MODEL_NAME = "microsoft/resnet-50"
 
 def execute(triton_client, model_name, inputs):
     # Set the input data
-    triton_inputs = [httpclient.InferInput("args_0", inputs["pixel_values"].shape, "FP32")]
+    triton_inputs = [
+        httpclient.InferInput("args_0", inputs["pixel_values"].shape, "FP32")
+    ]
     triton_inputs[0].set_data_from_numpy(inputs["pixel_values"])
 
     print("Executing model...")
     results = triton_client.infer(model_name, triton_inputs).as_numpy("logits")
     print("Model executed.\n")
-    
+
     return results
 
 
@@ -48,13 +50,17 @@ def main():
     # Parse args
     parser = ArgumentParser(description=DESCRIPTION)
     parser.add_argument(
-        "--input", type=str, metavar="<jpg>", required=True, help="Path to input image."
+        "--input",
+        type=str,
+        metavar="<jpg>",
+        required=True,
+        help="Path to input image.",
     )
     parser.add_argument(
         "--model-name",
         type=str,
         default=DEFAULT_MODEL_NAME,
-        help="Model name to execute inference."
+        help="Model name to execute inference.",
     )
     parser.add_argument(
         "--url",

--- a/examples/inference/stablediffusion-mojo-tensorflow/tokenizer.py
+++ b/examples/inference/stablediffusion-mojo-tensorflow/tokenizer.py
@@ -167,21 +167,23 @@ class SimpleTokenizer(object):
         return [49406] + bpe_tokens + [49407]
 
     def tokenize(self, prompt, N) -> np.ndarray:
-        '''
+        """
         Tokenize & pad the given prompt.
         Returns: (token_ids, position_ids)
         Raises: ValueError if given prompt exceeds encoder range.
-        '''
+        """
         # Tokenize prompt
         tokens = self.encode(prompt)
 
         # Pad prompt if shorter than N
         if len(tokens) < N:
-            tokens += [49407] * (N-len(tokens))
+            tokens += [49407] * (N - len(tokens))
 
         # Throw an error if the prompt is too long.
         if len(tokens) > N:
-            raise ValueError(f'Prompt (len={len(tokens)} cannot exceed {N} tokens.')
+            raise ValueError(
+                f"Prompt (len={len(tokens)} cannot exceed {N} tokens."
+            )
 
         # Return token & position IDs
         return np.array(tokens)

--- a/examples/inference/stablediffusion-python-tensorflow/download-model.py
+++ b/examples/inference/stablediffusion-python-tensorflow/download-model.py
@@ -30,8 +30,6 @@ import tensorflow as tf
 logger = tf.get_logger()
 logger.setLevel(logging.ERROR)
 
-from max import engine
-
 
 DEFAULT_MODEL_DIR = "stable-diffusion"
 DESCRIPTION = "Download a Stable Diffusion model."


### PR DESCRIPTION
Run `black` on Python source files and remove an extra `from max import engine` call in the Stable Diffusion Python TensorFlow example