### PR TITLE
[Graph API] Don't `set -e` in setup

### DIFF
--- a/examples/graph-api/llama2/setup.sh
+++ b/examples/graph-api/llama2/setup.sh
@@ -11,8 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-set -e
-
 # Usage: source setup.sh
 
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE:-0}")"


### PR DESCRIPTION
This is really annoying, if you source this it applies to your main shell which is bad news.