### PR TITLE
Stable Diffusion: Consolidate model downloads into a top level, gitignored directory [1/N]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ cython_debug/
 
 # VS Code
 .vscode
+
+# Downloaded example models
+examples/models/

--- a/examples/inference/stablediffusion-mojo-tensorflow/.gitignore
+++ b/examples/inference/stablediffusion-mojo-tensorflow/.gitignore
@@ -1,2 +1,1 @@
 output.png
-stable-diffusion/

--- a/examples/inference/stablediffusion-mojo-tensorflow/run.sh
+++ b/examples/inference/stablediffusion-mojo-tensorflow/run.sh
@@ -3,7 +3,7 @@
 # If anything goes wrong, stop running the script.
 set -e
 
-MODEL_DIR="stable-diffusion"
+MODEL_DIR="../../models/stable-diffusion-tensorflow"
 NPROMPT="ugly, bad anatomy, weird tongue"
 PPROMPT="Cute puppy chewing on a big steak"
 

--- a/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
+++ b/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
@@ -155,7 +155,7 @@ fn main() raises -> None:
     var negative_prompt: String = ''
     var num_steps: Int = 25
     var seed: Int = 0
-    var model_dir: String = 'stable-diffusion'
+    var model_dir: String = '../../models/stable-diffusion-tensorflow'
     var output: String = 'output.png'
 
     for i in range(1,len(argv),2):

--- a/examples/inference/stablediffusion-python-tensorflow/.gitignore
+++ b/examples/inference/stablediffusion-python-tensorflow/.gitignore
@@ -1,2 +1,1 @@
 output.png
-stable-diffusion/

--- a/examples/inference/stablediffusion-python-tensorflow/run.sh
+++ b/examples/inference/stablediffusion-python-tensorflow/run.sh
@@ -3,7 +3,7 @@
 # If anything goes wrong, stop running the script.
 set -e
 
-MODEL_DIR="stable-diffusion"
+MODEL_DIR="../../models/stable-diffusion-tensorflow"
 NPROMPT="bad anatomy, looking away, looking sideways, crooked stick"
 NPROMPT="$NPROMPT, stick not going through jaw, orange tongue"
 PPROMPT="Cute puppy chewing on a stick"

--- a/examples/inference/stablediffusion-python-tensorflow/text-to-image.py
+++ b/examples/inference/stablediffusion-python-tensorflow/text-to-image.py
@@ -29,7 +29,7 @@ from constants import _ALPHAS_CUMPROD as ALPHAS
 from math import log, sqrt
 from PIL import Image
 
-DEFAULT_MODEL_DIR = "stable-diffusion"
+DEFAULT_MODEL_DIR = "../../models/stable-diffusion-tensorflow"
 DESCRIPTION = "Generate an image based on the given prompt."
 GUIDANCE_SCALE_FACTOR = 7.5
 


### PR DESCRIPTION
This is a first of `N` PRs moves a subset of downloaded example models into a central, gitignored `models` subdirectory. By the end of it, we won't have to re-download the same models across different examples / scripts within this repository.

This PR covers `Stable Diffusion` examples within the `inference` subdirectory.

The gitignored `models` subdirectory looks something like this when most examples are run:
<img width="324" alt="Screenshot 2024-02-27 at 6 36 13 PM" src="https://github.com/modularml/max/assets/5534262/85942f48-cf3a-4298-9045-3f3b5d8d261c">


## Tests
Stable Diffusion
<img width="1318" alt="Screenshot 2024-02-27 at 6 05 35 PM" src="https://github.com/modularml/max/assets/5534262/9d2fe152-5345-47b8-9fa6-2c47ce1974a1">
