### PR TITLE
RoBERTa: Consolidate common, downloaded models into a top level, gitignored directory [2/N]

### DIFF
--- a/examples/inference/roberta-python-tensorflow/.gitignore
+++ b/examples/inference/roberta-python-tensorflow/.gitignore
@@ -1,2 +1,1 @@
-roberta/
 model-repository/

--- a/examples/inference/roberta-python-tensorflow/README.md
+++ b/examples/inference/roberta-python-tensorflow/README.md
@@ -21,7 +21,8 @@ bash deploy.sh
 - `download-model.py`
     Downloads the model from HuggingFace, converts it to a TensorFlow
     [SavedModel](https://www.tensorflow.org/guide/saved_model),
-    and saves it to an output directory of your choosing, or defaults to `roberta/`.
+    and saves it to an output directory of your choosing, or defaults to
+    `../../models/roberta-tensorflow/`.
 
     For more information about the model, please refer to the
     [model card](https://huggingface.co/microsoft/RoBERTa).

--- a/examples/inference/roberta-python-tensorflow/deploy.sh
+++ b/examples/inference/roberta-python-tensorflow/deploy.sh
@@ -4,7 +4,7 @@
 set -e
 
 INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"
-MODEL_DIR="roberta"
+MODEL_DIR="../../models/roberta-tensorflow"
 
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"

--- a/examples/inference/roberta-python-tensorflow/deploy.sh
+++ b/examples/inference/roberta-python-tensorflow/deploy.sh
@@ -4,7 +4,7 @@
 set -e
 
 INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"
-MODEL_DIR="../../models/roberta-tensorflow"
+MODEL_DIR="roberta"
 
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"

--- a/examples/inference/roberta-python-tensorflow/download-model.py
+++ b/examples/inference/roberta-python-tensorflow/download-model.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from transformers import TFRobertaForSequenceClassification
 
 
-DEFAULT_MODEL_DIR = "roberta"
+DEFAULT_MODEL_DIR = "../../models/roberta-tensorflow"
 DESCRIPTION = "Download a RoBERTa model."
 HF_MODEL_NAME = "cardiffnlp/twitter-roberta-base-emotion-multilabel-latest"
 

--- a/examples/inference/roberta-python-tensorflow/run.sh
+++ b/examples/inference/roberta-python-tensorflow/run.sh
@@ -4,7 +4,7 @@
 set -e
 
 INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"
-MODEL_DIR="roberta"
+MODEL_DIR="../../models/roberta-tensorflow"
 
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"

--- a/examples/inference/roberta-python-tensorflow/simple-inference.py
+++ b/examples/inference/roberta-python-tensorflow/simple-inference.py
@@ -25,7 +25,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 from argparse import ArgumentParser
 from transformers import AutoTokenizer, TFRobertaForSequenceClassification
 
-DEFAULT_MODEL_DIR = "roberta"
+DEFAULT_MODEL_DIR = "../../models/roberta-tensorflow"
 DESCRIPTION = "Identify the sentiment of an input statement."
 HF_MODEL_NAME = "cardiffnlp/twitter-roberta-base-emotion-multilabel-latest"
 

--- a/examples/tools/benchmark-pytorch/run.sh
+++ b/examples/tools/benchmark-pytorch/run.sh
@@ -7,10 +7,10 @@ set -e
 cd "$(dirname "$0")"
 
 # If RoBERTa hasn't been downloaded yet, download it.
-if ! [ -f ../common/roberta-pytorch/roberta.torchscript ]; then
-	../common/roberta-pytorch/download-model.sh -o ../common/roberta-pytorch/roberta.torchscript
+if ! [ -f ../../models/roberta.torchscript ]; then
+	../common/roberta-pytorch/download-model.sh -o ../../models/roberta.torchscript
 fi
 
 # Now for the easy part -- benchmarking ;)
 # PyTorch models require --input-data-schema to be specified.
-max benchmark --input-data-schema=../common/roberta-pytorch/input-spec.yaml ../common/roberta-pytorch/roberta.torchscript
+max benchmark --input-data-schema=../common/roberta-pytorch/input-spec.yaml ../../models/roberta.torchscript

--- a/examples/tools/benchmark-tensorflow/run.sh
+++ b/examples/tools/benchmark-tensorflow/run.sh
@@ -7,10 +7,10 @@ set -e
 cd "$(dirname "$0")"
 
 # If RoBERTa hasn't been downloaded yet, download it.
-if ! [ -d ../common/roberta-tensorflow/roberta-savedmodel ]; then
-	../common/roberta-tensorflow/download-model.sh -o ../common/roberta-tensorflow/roberta-savedmodel
+if ! [ -d ../../models/roberta-tensorflow ]; then
+	../common/roberta-tensorflow/download-model.sh -o ../../models/roberta-tensorflow
 fi
 
 # Now for the easy part -- benchmarking ;)
 # Even though this is a TensorFlow model, we need --input-data-schema in order to override how the inputs are generated, since the inputs must have a fixed range and the model has dynamic input shapes.
-max benchmark  --input-data-schema=../common/roberta-tensorflow/input-spec.yaml ../common/roberta-tensorflow/roberta-savedmodel
+max benchmark  --input-data-schema=../common/roberta-tensorflow/input-spec.yaml ../../models/roberta-tensorflow

--- a/examples/tools/common/resnet50-pytorch/.gitignore
+++ b/examples/tools/common/resnet50-pytorch/.gitignore
@@ -1,2 +1,1 @@
 *.bin
-*.torchscript

--- a/examples/tools/common/resnet50-tensorflow/.gitignore
+++ b/examples/tools/common/resnet50-tensorflow/.gitignore
@@ -1,1 +1,0 @@
-resnet50-savedmodel/

--- a/examples/tools/common/roberta-pytorch/.gitignore
+++ b/examples/tools/common/roberta-pytorch/.gitignore
@@ -1,2 +1,1 @@
 *.bin
-*.torchscript

--- a/examples/tools/common/roberta-tensorflow/.gitignore
+++ b/examples/tools/common/roberta-tensorflow/.gitignore
@@ -1,1 +1,0 @@
-roberta-savedmodel/


### PR DESCRIPTION
This is 2 of `N` PRs moves a subset of downloaded example models into a central, gitignored `models` subdirectory. By the end of it, we won't have to re-download the same models across different examples / scripts within this repository.

This PR covers `RoBERTa` examples within `inference/` and `tools/`. We skip `notebooks/` for now as that is a standalone workflow that doesn't rely on a prior downloaded model.

The gitignored `models` subdirectory looks something like this when most examples are run:
<img width="324" alt="Screenshot 2024-02-27 at 6 36 13 PM" src="https://github.com/modularml/max/assets/5534262/85942f48-cf3a-4298-9045-3f3b5d8d261c">


## Tests

### RoBERTa (TensorFlow) `inference`:

<img width="597" alt="Screenshot 2024-02-28 at 10 40 37 AM" src="https://github.com/modularml/max/assets/5534262/860bf3b9-4e2d-4a64-aefc-96386b0b2a4e">


NOTE: I did not make any changes to `deploy.sh` and `triton-inference.py` in this PR. They will keep their download model workflow respectively, at least for now.

### RoBERTa `tools`:

PyTorch benchmark:
<img width="764" alt="Screenshot 2024-02-28 at 10 25 42 AM" src="https://github.com/modularml/max/assets/5534262/a4672632-5948-40e5-a230-fc7bb73e8532">

TensorFlow benchmark:
<img width="427" alt="Screenshot 2024-02-28 at 10 27 48 AM" src="https://github.com/modularml/max/assets/5534262/c8c274b3-bddc-4435-9b33-8e7972514a04">

## Previous PRs:
1. #52 
