### PR TITLE
Minor bugfix in performance-showcase example (fix output bugs)

### DIFF
--- a/examples/performance-showcase/common.py
+++ b/examples/performance-showcase/common.py
@@ -160,7 +160,7 @@ def shell(commands, stdout=subprocess.PIPE, print_progress=False, env={}):
     while task is not None:
         if task.poll() is not None:
             try:
-                task = subprocess.Popen(next(tasks), stdout=stdout)
+                task = subprocess.Popen(next(tasks), stdout=stdout, stderr=subprocess.STDOUT, env=my_env)
                 tasks_completed += 1
             except:
                 task = None


### PR DESCRIPTION
Subsequent calls to subprocess were not getting the ENV and stderr options plumbed through to, which caused some collision on printouts. 