### PR TITLE
Migrate MAX Serving images to a public ECR with the modular alias

### DIFF
--- a/examples/inference/bert-python-torchscript/deploy.sh
+++ b/examples/inference/bert-python-torchscript/deploy.sh
@@ -31,7 +31,7 @@ echo "Starting container"
 CONTAINER_ID=$(\
   docker run --rm -d --net=host \
     -v $(pwd)/model-repository:/model-repository \
-    public.ecr.aws/o4d0h4e7/max-serving-de \
+    public.ecr.aws/modular/max-serving-de \
     tritonserver --model-repository=/model-repository \
     --load-model=${MODEL_DIR} \
 )

--- a/examples/inference/resnet50-python-tensorflow/deploy.sh
+++ b/examples/inference/resnet50-python-tensorflow/deploy.sh
@@ -30,7 +30,7 @@ echo "Starting container"
 CONTAINER_ID=$(\
   docker run --rm -d --net=host --ipc=host \
     -v $(pwd)/model-repository:/model-repository \
-    public.ecr.aws/o4d0h4e7/max-serving-de \
+    public.ecr.aws/modular/max-serving-de \
     tritonserver --model-repository=/model-repository \
     --load-model=resnet-50 \
 )

--- a/examples/inference/roberta-python-tensorflow/deploy.sh
+++ b/examples/inference/roberta-python-tensorflow/deploy.sh
@@ -30,7 +30,7 @@ echo "Starting container"
 CONTAINER_ID=$(\
   docker run --rm -d --net=host --ipc=host \
     -v $(pwd)/model-repository:/model-repository \
-    public.ecr.aws/o4d0h4e7/max-serving-de \
+    public.ecr.aws/modular/max-serving-de \
     tritonserver --model-repository=/model-repository \
     --load-model=${MODEL_DIR} \
 )


### PR DESCRIPTION
MAX Serving images are now available under `public.ecr.aws/modular/max-serving-de`. This PR changes the examples to point to that registry. The browsable link to the registry https://gallery.ecr.aws/modular/max-serving-de