### PR TITLE
[WIP] BERT TensorFlow: Consolidate common, downloaded models into a top level, gitignored directory [4/N]

### DIFF
--- a/examples/inference/bert-c-tensorflow/.gitignore
+++ b/examples/inference/bert-c-tensorflow/.gitignore
@@ -1,6 +1,3 @@
-# Model directories
-bert-tf-model
-
 # Binaries generated
 inputs
 outputs.bin

--- a/examples/inference/bert-c-tensorflow/README.md
+++ b/examples/inference/bert-c-tensorflow/README.md
@@ -45,5 +45,5 @@ The executable is called `bert` and will be present in the build directory.
 - Make sure `bin` directory of `max` package is in `PATH`.
 
 ```sh
-./build/bert ./bert-tf-model
+./build/bert ../../models/bert-tensorflow
 ```

--- a/examples/inference/bert-c-tensorflow/download-model.py
+++ b/examples/inference/bert-c-tensorflow/download-model.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from transformers import TFBertForMaskedLM
 
 HF_MODEL_NAME = "bert-base-uncased"
-DEFAULT_MODEL_DIR = "bert-tf-model"
+DEFAULT_MODEL_DIR = "../../models/bert-tensorflow"
 
 
 def main():

--- a/examples/inference/bert-c-tensorflow/run.sh
+++ b/examples/inference/bert-c-tensorflow/run.sh
@@ -12,7 +12,7 @@ MAX_PKG_DIR="$(modular config max.path)"
 export MAX_PKG_DIR
 
 CURRENT_DIR=$(dirname "$0")
-MODEL_DIR="$CURRENT_DIR/bert-tf-model"
+MODEL_DIR="$CURRENT_DIR/../../models/bert-tensorflow"
 
 # Download model from HuggingFace
 python3 "$CURRENT_DIR/download-model.py" "--output-dir=$MODEL_DIR"

--- a/examples/inference/bert-c-torchscript/run.sh
+++ b/examples/inference/bert-c-torchscript/run.sh
@@ -7,7 +7,7 @@ MAX_PKG_DIR="$(modular config max.path)"
 export MAX_PKG_DIR
 
 CURRENT_DIR=$(dirname "$0")
-MODEL_PATH="bert-base-uncased.torchscript"
+MODEL_PATH="$CURRENT_DIR/../../models/bert.torchscript"
 
 # Example input for the model
 INPUT_EXAMPLE="My dog is cute."

--- a/examples/inference/bert-python-torchscript/.gitignore
+++ b/examples/inference/bert-python-torchscript/.gitignore
@@ -1,4 +1,1 @@
-# Don't check in / version control the downloaded model
-*.pt
-*.torchscript
 model-repository/

--- a/examples/inference/bert-python-torchscript/download-model.py
+++ b/examples/inference/bert-python-torchscript/download-model.py
@@ -27,7 +27,7 @@ os.environ["TRANSFORMERS_VERBOSITY"] = "critical"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 HF_MODEL_NAME = "bert-base-uncased"
-DEFAULT_MODEL_PATH = "bert.torchscript"
+DEFAULT_MODEL_PATH = "../../models/bert.torchscript"
 
 
 def main():

--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -2,8 +2,10 @@
 
 set -ex
 
-CURRENT_DIR=$(dirname "$0")
-MODEL_PATH="$CURRENT_DIR/../../models/bert.torchscript"
+# Example input for the model
+INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"
+
+MODEL_PATH="../../models/bert.torchscript"
 
 # Make sure we're running from inside the directory containing this file.
 cd "$(dirname "$0")"

--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -13,4 +13,4 @@ cd "$(dirname "$0")"
 # Download model from HuggingFace
 python3 download-model.py -o "$MODEL_PATH"
 
-python3 simple-inference.py" --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"
+python3 simple-inference.py --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"

--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -13,4 +13,4 @@ cd "$(dirname "$0")"
 # Download model from HuggingFace
 python3 download-model.py -o "$MODEL_PATH"
 
-python3 "$CURRENT_DIR/simple-inference.py" --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"
+python3 simple-inference.py" --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"

--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -3,12 +3,12 @@
 set -ex
 
 CURRENT_DIR=$(dirname "$0")
-MODEL_PATH="$CURRENT_DIR/bert.torchscript"
+MODEL_PATH="$CURRENT_DIR/../../models/bert.torchscript"
 
-# Example input for the model
-INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"
+# Make sure we're running from inside the directory containing this file.
+cd "$(dirname "$0")"
 
 # Download model from HuggingFace
-python3 "$CURRENT_DIR/download-model.py" -o "$MODEL_PATH"
+python3 download-model.py -o "$MODEL_PATH"
 
 python3 "$CURRENT_DIR/simple-inference.py" --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"

--- a/examples/inference/bert-python-torchscript/simple-inference.py
+++ b/examples/inference/bert-python-torchscript/simple-inference.py
@@ -26,7 +26,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 BATCH = 1
 SEQLEN = 128
-DEFAULT_MODEL_PATH = "bert.torchscript"
+DEFAULT_MODEL_PATH = "../../models/bert.torchscript"
 DESCRIPTION = "BERT model"
 HF_MODEL_NAME = "bert-base-uncased"
 


### PR DESCRIPTION
This is 4 of `N` PRs moves a subset of downloaded example models into a central, gitignored `models` subdirectory. By the end of it, we won't have to re-download the same models across different examples / scripts within this repository.

This PR covers `BERT` examples within `inference/`.

The gitignored `models` subdirectory looks something like this when most examples are run:
<img width="324" alt="Screenshot 2024-02-27 at 6 36 13 PM" src="https://github.com/modularml/max/assets/5534262/85942f48-cf3a-4298-9045-3f3b5d8d261c">


## Tests

### BERT C TensorFlow
<img width="718" alt="Screenshot 2024-02-28 at 2 21 42 PM" src="https://github.com/modularml/max/assets/5534262/427ddd0b-4cf5-4668-81d4-7ec9f9162743">

TODO:
- [ ] Still need to fix BERT across C and Python TorchScript examples. Both have different dict keys.
- [ ] Python TorchScript version has inverse sentiment values.

## Previous PRs:
1. #52
2. #53
3. #56 
