### PR TITLE
Fix model path in BERT python torchscript run.sh

### DIFF
--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -11,4 +11,4 @@ INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastru
 # Download model from HuggingFace
 python3 "$CURRENT_DIR/download-model.py" -o "$MODEL_PATH"
 
-python3 simple-inference.py --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"
+python3 "$CURRENT_DIR/simple-inference.py" --text "$INPUT_EXAMPLE" --model-path "$MODEL_PATH"

--- a/examples/inference/bert-python-torchscript/run.sh
+++ b/examples/inference/bert-python-torchscript/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 CURRENT_DIR=$(dirname "$0")
-MODEL_PATH="bert.torchscript"
+MODEL_PATH="$CURRENT_DIR/bert.torchscript"
 
 # Example input for the model
 INPUT_EXAMPLE="There are many exciting developments in the field of AI Infrastructure!"


### PR DESCRIPTION
This PR fixes a `$MODEL_PATH` env variable bug in BERT Python TorchScript example. This env variable fails to "follow" where the `run.sh` script is run from. There was also another bug around `simple-inference.py` where we implicitly depend on running it on the same subdirectory level as `run.sh`. While this is true, it would break almost immediately any other directory level.

## Tests
<img width="1070" alt="Screenshot 2024-02-28 at 3 03 39 PM" src="https://github.com/modularml/max/assets/5534262/5dc87d9c-9fc5-412f-aac9-d43f0672ee70">
