### PR TITLE
Add import of max engine to the beginning of run.py to avoid the TLS issue).

### DIFF
--- a/examples/performance-showcase/run.py
+++ b/examples/performance-showcase/run.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from max import engine
 import os
 import subprocess
 import common
@@ -43,7 +44,7 @@ shell(commands, print_progress=True, env={"TF_CPP_MIN_LOG_LEVEL": "9"})
 print("\nStarting inference throughput comparison")
 try:
     import cpuinfo
-    
+
     cpu = cpuinfo.get_cpu_info()
 
     keys = ["brand_raw", "arch", "hz_advertised_friendly", "count"]

--- a/examples/performance-showcase/run_max.py
+++ b/examples/performance-showcase/run_max.py
@@ -11,9 +11,9 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from max import engine
 import pickle
 import common
-from max import engine
 import numpy as np
 import sys
 

--- a/examples/performance-showcase/run_pt.py
+++ b/examples/performance-showcase/run_pt.py
@@ -45,7 +45,7 @@ if model_name == "roberta":
             torch.from_numpy(inputs["attention_mask"]),
             torch.from_numpy(inputs["token_type_ids"]),
         ]
-        
+
     with torch.inference_mode():
         qps = common.run(lambda: loaded.forward(*inputs))
     common.save_result("pt", qps)

--- a/examples/performance-showcase/run_tf.py
+++ b/examples/performance-showcase/run_tf.py
@@ -50,7 +50,7 @@ elif model_name == "clip":
     if not os.path.exists(model_path):
         model = TFCLIPModel.from_pretrained("openai/clip-vit-base-patch32")
         tf.saved_model.save(model, model_dir)
-        
+
     with open(".cache/clip.pkl", "rb") as f:
         inputs = pickle.load(f)
         inputs = {


### PR DESCRIPTION
Without it the package was imported in `test_requirements` function after other packages and caused the TLS problem.

Details about the TLS issue: https://docs.modular.com/engine/roadmap#pytorch-error-cannot-allocate-memory-in-static-tls-block