### PR TITLE
Fix Stable Diffusion Mojo parse arg typo

### DIFF
--- a/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
+++ b/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
@@ -178,7 +178,7 @@ fn main() raises -> None:
     # Only required arg is --prompt
     if prompt == '':
         print(USAGE)
-        raise Error('--prompt option is require')
+        raise Error('--prompt option is required')
 
     random.seed(seed)
 


### PR DESCRIPTION
Fix a small typo in our Mojo Stable Diffusion example script.