### PR TITLE
Bring examples up to speed to latest Mojo-SDK

### DIFF
--- a/examples/graph-api/llama2/model/llama.🔥
+++ b/examples/graph-api/llama2/model/llama.🔥
@@ -179,7 +179,7 @@ struct Transformer:
     var n_heads: Int
 
     var embedding: Embedding
-    var layers: DynamicVector[TransformerBlock]
+    var layers: List[TransformerBlock]
     var norm: RMSNorm
     var output: Symbol
 
@@ -202,8 +202,8 @@ struct Transformer:
         var h = self.embedding(tokens)
         var freqs_cis = self.freqs_cis(start_pos, ops.shape_of(tokens)[1])
 
-        var k_cache_updates = DynamicVector[Symbol]()
-        var v_cache_updates = DynamicVector[Symbol]()
+        var k_cache_updates = List[Symbol]()
+        var v_cache_updates = List[Symbol]()
         for i in range(len(self.layers)):
             var layer_out = self.layers[i](
                 h, start_pos, freqs_cis, k_cache[i, axis=1], v_cache[i, axis=1]
@@ -260,7 +260,7 @@ struct Llama2[ModelT: LoadableModel]:
         fn weight(name: String, i: Optional[Int] = None) raises -> Symbol:
             return g.constant(self.params.get[DType.float32](name, i))
 
-        var layers = DynamicVector[TransformerBlock]()
+        var layers = List[TransformerBlock]()
         for i in range(self.hyperparams.n_layers):
             var layer = TransformerBlock(
                 attention=Attention(

--- a/examples/graph-api/llama2/run.🔥
+++ b/examples/graph-api/llama2/run.🔥
@@ -13,7 +13,7 @@
 
 from sys.param_env import env_get_string
 from tensor import Tensor, TensorShape
-from collections.vector import DynamicVector
+from collections import List
 from utils.index import Index
 from pathlib import Path
 

--- a/examples/graph-api/llama2/tokenizer/ball.🔥
+++ b/examples/graph-api/llama2/tokenizer/ball.🔥
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """A simple arena linked-list implementation."""
 
-from collections import DynamicVector, Optional
+from collections import List, Optional
 
 
 @value
@@ -48,13 +48,13 @@ struct Ball[T: CollectionElement]:
 
     alias ID = Int
 
-    var _arena: DynamicVector[Optional[Node[T]]]
+    var _arena: List[Optional[Node[T]]]
     var _head: Optional[Self.ID]
     var _tail: Optional[Self.ID]
 
     fn __init__(inout self):
         """Constructs a new empty linked list."""
-        self._arena = DynamicVector[Optional[Node[T]]]()
+        self._arena = List[Optional[Node[T]]]()
         self._head = None
         self._tail = None
 

--- a/examples/graph-api/llama2/tokenizer/bpe.🔥
+++ b/examples/graph-api/llama2/tokenizer/bpe.🔥
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """A byte pair encoding tokenizer implementation for use with LLMs."""
 
-from collections import Dict, DynamicVector, Optional
+from collections import Dict, List, Optional
 from pathlib import Path
 
 from .ball import Ball
@@ -77,7 +77,7 @@ struct BPETokenizer:
     algorithmic performance, but not fully optimized.
     """
 
-    var vocab: DynamicVector[Token]
+    var vocab: List[Token]
     var token_ids: Dict[String, Int]
 
     @staticmethod
@@ -124,7 +124,7 @@ struct BPETokenizer:
 
     fn __init__(inout self):
         """Create an empty tokenizer."""
-        self.vocab = DynamicVector[Token]()
+        self.vocab = List[Token]()
         self.token_ids = Dict[String, Int]()
 
     fn __moveinit__(inout self, owned existing: Self):
@@ -142,7 +142,7 @@ struct BPETokenizer:
         str: String,
         bos: Optional[String] = None,
         eos: Optional[String] = None,
-    ) raises -> DynamicVector[TokenWithID]:
+    ) raises -> List[TokenWithID]:
         """Encode a string according to the BPE algorithm.
 
         The BPE vocabulary is a set of scored strings. BPE starts by
@@ -158,7 +158,7 @@ struct BPETokenizer:
         they're expecting. Linked list elements only stop existing or grow
         in length, so we can always safely recognize an outdated merge.
         """
-        var output = DynamicVector[TokenWithID]()
+        var output = List[TokenWithID]()
         if bos and bos.value() in self.token_ids:
             output.append(TokenWithID(bos.value(), self.token_ids[bos.value()]))
 

--- a/examples/graph-api/llama2/tokenizer/max_heap.🔥
+++ b/examples/graph-api/llama2/tokenizer/max_heap.🔥
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """A simple generic max-heap implementation."""
 
-from collections.vector import DynamicVector
+from collections import List
 
 
 trait Orderable:
@@ -43,12 +43,12 @@ struct MaxHeap[ElementType: OrderableElement](Sized, Boolable):
     ```
     """
 
-    var heap: DynamicVector[ElementType]
+    var heap: List[ElementType]
     var begin_idx: Int
 
     fn __init__(inout self):
         """Constructs an empty heap."""
-        self.heap = DynamicVector[ElementType]()
+        self.heap = List[ElementType]()
         self.begin_idx = 0
 
     fn __len__(self) -> Int:

--- a/examples/graph-api/llama2/weights/gguf.🔥
+++ b/examples/graph-api/llama2/weights/gguf.🔥
@@ -42,7 +42,7 @@ Other types expose a `.destroy()` method simply to facilitate this.
 """
 
 from collections.optional import Optional
-from collections.vector import DynamicVector
+from collections import List
 from memory.unsafe import DTypePointer
 from tensor import Tensor, TensorShape
 from pathlib import Path
@@ -818,14 +818,14 @@ struct GGUFTensorInfo:
             num_elements * type_trait.type_size // type_trait.blck_size
         ).to_int()
 
-    fn tensor_dims(self) -> DynamicVector[Int]:
+    fn tensor_dims(self) -> List[Int]:
         """Converts from GGML `ne` to dims compatible with stdlib `Tensor`.
 
         Returns:
-            A `DynamicVector` of dims compatible with stdlib `TensorShape`.
+            A `List` of dims compatible with stdlib `TensorShape`.
         """
         var n_dims = int(self.n_dims)
-        var dims = DynamicVector[Int](capacity=n_dims)
+        var dims = List[Int](capacity=n_dims)
         for i in range(n_dims):
             # Opposite to `TensorSpec`, GGUF stores the inner dimension at
             # the smaller index, so reverse them.

--- a/examples/inference/stablediffusion-mojo-tensorflow/python_utils.🔥
+++ b/examples/inference/stablediffusion-mojo-tensorflow/python_utils.🔥
@@ -20,7 +20,7 @@
 import python
 from memory import memcpy
 from tensor import Tensor, TensorShape
-from collections.vector import DynamicVector
+from collections import List
 
 
 fn expandvars(path: String) raises -> String:
@@ -101,7 +101,7 @@ fn tensor_to_numpy[
 
 @always_inline
 fn numpy_to_tensor[type: DType](array: PythonObject) raises -> Tensor[type]:
-    var shape = DynamicVector[Int]()
+    var shape = List[Int]()
     var array_shape = array.shape
     for dim in array_shape:
         shape.push_back(dim.__index__())

--- a/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
+++ b/examples/inference/stablediffusion-mojo-tensorflow/text-to-image.🔥
@@ -18,7 +18,7 @@ import random
 
 from os import setenv
 
-from collections.vector import DynamicVector
+from collections import List
 from math import exp, log, sin, cos, sqrt
 from memory import memcpy
 from python import Python
@@ -73,7 +73,7 @@ fn reverse[dtype: DType](x: Tensor[dtype]) -> Tensor[dtype]:
 fn vstack[dtype: DType](a: Tensor[dtype], b: Tensor[dtype]) -> Tensor[dtype]:
     """Concatenate tensors a & b along the outermost dimension."""
     # Generate return shape
-    var out_shape = DynamicVector[Int]()
+    var out_shape = List[Int]()
     out_shape.push_back(a.shape()[0] + b.shape()[0])
     for i in range(1, a.shape().rank()):
         out_shape.append(a.shape()[i])
@@ -88,7 +88,7 @@ fn vstack[dtype: DType](a: Tensor[dtype], b: Tensor[dtype]) -> Tensor[dtype]:
 fn split[dtype: DType](x: Tensor[dtype], i: Int) -> Tensor[dtype]:
     """Return the ith slice of the outermost dim; i.e., x[idx, :, :, ..., :]."""
     # Generate return shape
-    var shape = DynamicVector[Int]()
+    var shape = List[Int]()
     shape.push_back(1)
     for i in range(1, x.shape().rank()):
         shape.push_back(x.shape()[i])


### PR DESCRIPTION
As DynamicVector was renamed to List in the latest iteration of the Mojo SDK, max examples started being out of date. This patch fixes that.

Fixes https://github.com/modularml/modular/issues/33434