### PR TITLE
Use consistent output args in all inference examples. 

### DIFF
--- a/examples/inference/bert-c-tensorflow/download-model.py
+++ b/examples/inference/bert-c-tensorflow/download-model.py
@@ -26,6 +26,7 @@ def main():
     parser = ArgumentParser(description="Download model for inference.")
     parser.add_argument(
         "--output-dir",
+        "-o",
         type=str,
         help="Location to save the model",
         default=DEFAULT_MODEL_DIR,

--- a/examples/inference/bert-c-tensorflow/run.sh
+++ b/examples/inference/bert-c-tensorflow/run.sh
@@ -28,7 +28,7 @@ CURRENT_DIR=$(dirname "$0")
 MODEL_DIR="$CURRENT_DIR/../../models/bert-tensorflow"
 
 # Download model from HuggingFace
-python3 "$CURRENT_DIR/download-model.py" "--output-dir=$MODEL_DIR"
+python3 "$CURRENT_DIR/download-model.py" "-o $MODEL_DIR"
 
 # Execute the model with example input
 INPUT_EXAMPLE="The capital of France is [MASK]."


### PR DESCRIPTION
Adding "-o" option to BERT C example for consistency. 