### PR TITLE
Add corrections, clarity, and cleanup to inference READMEs

### DIFF
--- a/examples/inference/bert-c-tensorflow/README.md
+++ b/examples/inference/bert-c-tensorflow/README.md
@@ -1,8 +1,15 @@
-# Tensorflow BERT Inference
+# Tensorflow BERT inference with C
 
-This directory includes scripts used to run simple BERT inference via the MAX Engine C API to predict the masked text. In this case, we use the text _"The capital of France is [MASK]."_ as an example.
+This directory includes scripts used to run simple BERT inference via the MAX
+Engine C API to predict the masked text. In this case, we use the text _"The
+capital of France is [MASK]."_ as an example.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
@@ -11,26 +18,32 @@ python3 -m pip install -r requirements.txt
 bash run.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `download-model.py`
+- `download-model.py`: Downloads the model from HuggingFace, converts it to a
+`TensorFlow SavedModel`, and saves it to directory `bert`.
 
-    Downloads the model from HuggingFace, converts it to a `TensorFlow Saved Model`, and saves it to directory `bert`.
+    For more information about the model, reference the [model
+    card](https://huggingface.co/bert-base-uncased).
 
-    For more information about the model, reference the [model card](https://huggingface.co/bert-base-uncased).
+- `generate-inputs.py`: Prepares an example input and saves the pre-processed
+input to a local directory. Example:
 
-- `generate-inputs.py`
+  ```sh
+  python3 generate-inputs.py --input="Paris is the [MASK] of France."
+  ```
 
-    Prepares an example input and saves the pre-processed input to a local directory.
-    To specify an input example, use `python3 generate-inputs.py --input=<masked text>`.
+- `post-process.py`: Loads the generated output, post-processes it, and outputs
+the prediction. Example:
 
-- `post-process.py`
-    Loads the generated output, post-processes it, and outputs the prediction.
-    Usage: `python3 post-process.py --input=<masked text>`.
+  ```sh
+  python3 post-process.py --input="Paris is the [MASK] of France."
+  ```
 
 ## Building the example
 
-This example uses CMake. To build the executable, please use the following commands:
+This example uses CMake. To build the executable, please use the following
+commands:
 
 ```sh
 export MAX_PKG_DIR=`modular config max.path`

--- a/examples/inference/bert-c-torchscript/README.md
+++ b/examples/inference/bert-c-torchscript/README.md
@@ -1,8 +1,14 @@
-# TorchScript BERT Inference
+# TorchScript BERT inference with C
 
-This directory includes scripts used to run simple BERT inference via the MAX Engine C API to predict the sentiment of the given text.
+This directory includes scripts used to run simple BERT inference via the MAX
+Engine C API to predict the sentiment of the given text.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```
 python3 -m venv venv && source venv/bin/activate
@@ -11,19 +17,26 @@ python3 -m pip install -r requirements.txt
 bash run.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `pre-process.py`
-    Loads the generated output, post-processes it, and outputs the prediction.
-    Usage: `python3 pre-process.py --text <masked text>`
+- `pre-process.py`: Prepares an example input and saves the pre-processed input
+to a local directory, for use use in the `main.c` program. Example:
 
-- `post-process.py`
-    Loads the generated output, post-processes it, and outputs the prediction.
-    Usage: `python3 post-process.py`.
+    ```sh
+    python3 pre-process.py --text "Paris is the [MASK] of France."
+    ```
+
+- `post-process.py`: Loads the generated output, post-processes it, and outputs
+the prediction. Example:
+
+    ```sh
+    python3 post-process.py
+    ```
 
 ## Building the example
 
-This example uses CMake. To build the executable, please use the following commands:
+This example uses CMake. To build the executable, please use the following
+commands:
 
 ```sh
 export MAX_PKG_DIR=`modular config max.path`

--- a/examples/inference/bert-c-torchscript/README.md
+++ b/examples/inference/bert-c-torchscript/README.md
@@ -10,7 +10,7 @@ guide](https://docs.modular.com/engine/get-started/).
 
 Then you can install the package requirements and run this example:
 
-```
+```sh
 python3 -m venv venv && source venv/bin/activate
 python3 -m pip install --upgrade pip setuptools
 python3 -m pip install -r requirements.txt

--- a/examples/inference/bert-python-torchscript/README.md
+++ b/examples/inference/bert-python-torchscript/README.md
@@ -1,9 +1,14 @@
-# TorchScript BERT Inference
+# TorchScript BERT inference with Python
 
 This directory includes scripts used to run simple BERT inference via the MAX
-Python API to predict the sentiment of the given text.
+Engine Python API to predict the masked words in a sentence.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
@@ -17,17 +22,27 @@ bash run.sh
 bash deploy.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `simple-inference.py`
-    Masked language model example input text using the MAX Engine. The script prepares an
-    example input, executes the model, and generates the filled mask.
+- `simple-inference.py`: Predicts the masked words in the input text using the
+MAX Engine Python API. The script prepares an example input, executes the
+model, and generates the filled mask.
 
     You can use the `--text` CLI flag to specify an input sentence.
-    For example, `python3 simple-inference.py --text "Paris is the [MASK] of France."`
+    For example:
 
-- `triton-inference.py`
-    Masked language model example input text using the MAX Serving. The script launches a Triton container, prepares an example input, executes the model by calling HTTP inference endpoint, and returns the filled mask.
+    ```sh
+    python3 simple-inference.py --text "Paris is the [MASK] of France."
+    ```
+
+- `triton-inference.py`: Predicts the masked words in the input text using MAX
+Serving. The script launches a Triton container, prepares an example input,
+executes the model by calling HTTP inference endpoint, and returns the filled
+mask.
 
     You can use the `--text` CLI flag to specify an input example.
-    For example, `python3 triton-inference.py --text "Paris is the [MASK] of France."`.
+    For example:
+
+    ```sh
+    python3 triton-inference.py --text "Paris is the [MASK] of France."
+    ```

--- a/examples/inference/resnet50-python-tensorflow/README.md
+++ b/examples/inference/resnet50-python-tensorflow/README.md
@@ -1,10 +1,15 @@
-# Tensorflow ResNet-50 Inference
+# Tensorflow ResNet-50 inference with Python
 
 This directory includes scripts used to run simple Resnet-50 inference via the
-MAX Engine to classify an input image. In this case, we use an image of a
-leatherback turtle as an example.
+MAX Engine Python API to classify an input image. In this case, we use an image
+of a leatherback turtle as an example.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
@@ -18,26 +23,34 @@ bash run.sh
 bash deploy.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `download-model.py`
-    Downloads the model from HuggingFace, converts it to a TensorFlow
-    [SavedModel](https://www.tensorflow.org/guide/saved_model),
-    and saves it to an output directory of your choosing, or defaults
-    to `../../models/resnet50-tensorflow/`.
+- `download-model.py`: Downloads the model from HuggingFace, converts it to a
+TensorFlow [SavedModel](https://www.tensorflow.org/guide/saved_model), and
+saves it to an output directory of your choosing, or defaults to
+`../../models/resnet50-tensorflow/`.
 
     For more information about the model, please refer to the
     [model card](https://huggingface.co/microsoft/resnet-50).
 
-- `simple-inference.py`
-    Classifies example input image using the MAX Engine. The script prepares an
-    example input, executes the model, and generates the resultant classification
-    output.
+- `simple-inference.py`: Classifies example input image using MAX Engine.
+The script prepares an example input, executes the model, and generates the
+resultant classification output.
 
     You can use the `--input` CLI flag to specify an input example.
-    For example, `python3 simple-inference.py --input=<path_to_input_jpg>`.
+    For example:
 
-- `triton-inference.py`
-    Classifies example input image using the MAX Serving container. The script launches a Triton container, prepares an example input, executes the model by calling HTTP inference endpoint, and returns the classification result.
+    ```sh
+    python3 simple-inference.py --input=<path_to_input_jpg>
+    ```
 
-    To specify a input example, use `python3 triton-inference.py --input=<path_to_input_jpg>`.
+- `triton-inference.py`: Classifies example input image using the MAX Serving
+container. The script launches a Triton container, prepares an example input,
+executes the model by calling HTTP inference endpoint, and returns the
+classification result.
+
+    To specify a input example, use:
+
+    ```sh
+    python3 triton-inference.py --input=<path_to_input_jpg>
+    ```

--- a/examples/inference/roberta-mojo-tensorflow/README.md
+++ b/examples/inference/roberta-mojo-tensorflow/README.md
@@ -1,9 +1,14 @@
-# Tensorflow RoBERTa Inference
+# Tensorflow RoBERTa inference with Mojo
 
 This directory includes scripts used to run simple RoBERTa inference via the
-MAX Engine and Mojo APIs to predict the sentiment of the given text.
+MAX Engine Mojo API to predict the sentiment of the given text.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
@@ -15,21 +20,23 @@ python3 -m pip install --find-links "$(modular config max.path)/wheels" max-engi
 bash run.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `download-model.py`
-    Downloads the model from HuggingFace, converts it to a TensorFlow
-    [SavedModel](https://www.tensorflow.org/guide/saved_model),
-    and saves it to an output directory of your choosing, or defaults to
-    `../../models/roberta-tensorflow/`.
+- `download-model.py`: Downloads the model from HuggingFace, converts it to a
+TensorFlow [SavedModel](https://www.tensorflow.org/guide/saved_model), and
+saves it to an output directory of your choosing, or defaults to
+`../../models/roberta-tensorflow/`.
 
     For more information about the model, please refer to the
     [model card](https://huggingface.co/microsoft/RoBERTa).
 
-- `simple-inference.🔥`
-    Classifies example input statement using the MAX Engine. The script prepares an
-    example input, executes the model, and generates the resultant classification
-    output.
+- `simple-inference.🔥`: Classifies example input statement using MAX
+Engine. The script prepares an example input, executes the model, and generates
+the resultant classification output.
 
     You can use the `--input` CLI flag to specify an input example.
-    For example, `mojo simple-inference.🔥 --input=<YOUR_INPUT_STRING_HERE>`.
+    For example:
+
+    ```sh
+    mojo simple-inference.🔥 --input=<YOUR_INPUT_STRING_HERE>
+    ```

--- a/examples/inference/roberta-python-tensorflow/README.md
+++ b/examples/inference/roberta-python-tensorflow/README.md
@@ -1,8 +1,14 @@
-# Tensorflow RoBERTa Inference
+# Tensorflow RoBERTa inference with Python
 
-This directory includes scripts used to run simple RoBERTa inference via the MAX Engine to predict the sentiment of the given text.
+This directory includes scripts used to run simple RoBERTa inference via the
+MAX Engine Python API to predict the sentiment of the given text.
 
 ## Quickstart
+
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```sh
 python3 -m venv venv && source venv/bin/activate
@@ -16,27 +22,35 @@ bash run.sh
 bash deploy.sh
 ```
 
-## Scripts Included
+## Scripts included
 
-- `download-model.py`
-    Downloads the model from HuggingFace, converts it to a TensorFlow
-    [SavedModel](https://www.tensorflow.org/guide/saved_model),
-    and saves it to an output directory of your choosing, or defaults to
-    `../../models/roberta-tensorflow/`.
+- `download-model.py`: Downloads the model from HuggingFace, converts it to a
+TensorFlow [SavedModel](https://www.tensorflow.org/guide/saved_model), and
+saves it to an output directory of your choosing, or defaults to
+`../../models/roberta-tensorflow/`.
 
     For more information about the model, please refer to the
     [model card](https://huggingface.co/microsoft/RoBERTa).
 
-- `simple-inference.py`
-    Classifies example input statement using the MAX Engine. The script prepares an
-    example input, executes the model, and generates the resultant classification
-    output.
+- `simple-inference.py`: Classifies example input statement using MAX
+Engine. The script prepares an example input, executes the model, and generates
+the resultant classification output.
 
     You can use the `--input` CLI flag to specify an input example.
-    For example, `python3 simple-inference.py --input=<YOUR_INPUT_STRING_HERE>`.
+    For example:
 
-- `triton-inference.py`
-    Classifies example input image using the MAX Serving. The script launches a Triton container, prepares an example input, executes the model by calling HTTP inference endpoint, and returns the classification result.
+    ```sh
+    python3 simple-inference.py --input=<YOUR_INPUT_STRING_HERE>
+    ```
+
+- `triton-inference.py`: Classifies example input image using MAX Serving.
+The script launches a Triton container, prepares an example input, executes the
+model by calling HTTP inference endpoint, and returns the classification
+result.
 
     You can use the `--input` CLI flag to specify an input example.
-    For example, `python3 triton-inference.py --input=<YOUR_INPUT_STRING_HERE>`.
+    For example:
+
+    ```sh
+    python3 triton-inference.py --input=<YOUR_INPUT_STRING_HERE>
+    ```

--- a/examples/inference/stablediffusion-mojo-tensorflow/README.md
+++ b/examples/inference/stablediffusion-mojo-tensorflow/README.md
@@ -1,12 +1,15 @@
-# Stable Diffusion Inference
+# Stable Diffusion inference with Mojo
 
-This directory illustrates how to run Stable Diffusion through the MAX AI Engine.
-Specifically, this example extracts StableDiffusion-1.4 from Keras-CV and executes
-it via the MAX Mojo API.
+This directory illustrates how to run Stable Diffusion through MAX Engine.
+Specifically, this example extracts StableDiffusion-1.4 from Keras-CV and
+executes it via the MAX Engine Mojo API.
 
 ## Quickstart
 
-Once you have the MAX AI engine installed, this example can be run with:
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
 
 ```bash
 python3 -m venv venv && source venv/bin/activate
@@ -18,16 +21,17 @@ python3 -m pip install --find-links "$(modular config max.path)/wheels" max-engi
 bash run.sh
 ```
 
-## Custom Images
+## Custom images
 
 Getting started with your own creative prompts is as simple as:
 
-```
+```sh
 mojo text-to-image.🔥 --prompt "my image description" -o my-image.png
 ```
 
 To refine images there are a few additional options:
 
-  - `--seed <int>`: Control PRNG initialization (default: 0)
-  - `--num-steps <int>`: Set # of denoising iterations (default: 25)
-  - `--negative-prompt <str>`: Textual description of items or styles to avoid. (default: None)
+- `--seed <int>`: Control PRNG initialization (default: 0)
+- `--num-steps <int>`: Set # of denoising iterations (default: 25)
+- `--negative-prompt <str>`: Textual description of items or styles to avoid.
+  (default: None)

--- a/examples/inference/stablediffusion-python-tensorflow/README.md
+++ b/examples/inference/stablediffusion-python-tensorflow/README.md
@@ -1,12 +1,16 @@
-# Stable Diffusion Inference
+# Stable Diffusion inference with Python
 
-This directory illustrates how to run Stable Diffusion through the MAX AI Engine.
+This directory illustrates how to run Stable Diffusion through MAX Engine.
 Specifically, this example extracts StableDiffusion-1.4 from Keras-CV and executes
-it via the MAX Python API.
+it via the MAX Engine Python API.
 
 ## Quickstart
 
-Once you have the MAX AI engine installed, this example can be run with:
+First, install MAX as per the [MAX Engine get started
+guide](https://docs.modular.com/engine/get-started/).
+
+Then you can install the package requirements and run this example:
+
 ```bash
 python3 -m venv venv && source venv/bin/activate
 python3 -m pip install --upgrade pip setuptools
@@ -31,13 +35,10 @@ details.
 
 ## Files
 
-- `download-model.py`
+- `download-model.py`: Downloads [keras SD
+model](https://github.com/keras-team/keras-cv/tree/master/keras_cv/models/stable_diffusion),
+exports each component model as a TF `SavedModel`, compiles & loads into
+MAX Engine and prints input/output info.
 
-  Download [keras SD model](https://github.com/keras-team/keras-cv/tree/master/keras_cv/models/stable_diffusion),
-  export each component model as a TF `SavedModel`, compile & load into
-  modular & print input/output info.
-
-- `text-to-image.py`
-
-  Example program which runs full stable-diffusion pipeline through the MAX AI
-  Engine in order to generate images from the given prompt.
+- `text-to-image.py`: Example program that runs full stable-diffusion pipeline
+through MAX Engine in order to generate images from the given prompt.


### PR DESCRIPTION
It appears some text was copy-pasted and wasn't correct for the example, and there was some incorrect product terminology. 

This also adds a link to the MAX Engine get started before trying to run any of the examples, puts all code snippets into code blocks for usability, improves page titles, and adds formatting to line length to make future diffs simpler and easier to comment upon in PRs.