### PR TITLE
performance-showcase: fixes "'addendum' referenced before assignment"

### DIFF
--- a/examples/performance-showcase/printouts.py
+++ b/examples/performance-showcase/printouts.py
@@ -61,7 +61,7 @@ def print_speedup_summary(results, model):
 
         modular_txt = f"MAX Engine vs {framework_labels[framework]}:"
 
-        if speedup > 1.5:
+        if speedup > 1.2:
             addendum = f"{next(exclamations)} We're {speedup:.2f}x faster!"
 
         if speedup <= 1.2:


### PR DESCRIPTION
 `addendum` was being left unassigned for speedup greater than 1.2 but less than or equal to 1.5.