### PR TITLE
performance-showcase: add tf-keras requirement

### DIFF
--- a/examples/performance-showcase/requirements.txt
+++ b/examples/performance-showcase/requirements.txt
@@ -3,3 +3,4 @@ tensorflow
 transformers
 py-cpuinfo
 torch
+tf-keras


### PR DESCRIPTION
fixes "RuntimeError: Failed to import transformers.models.roberta.modeling_tf_roberta because of the following error (look up to see its traceback): Your currently installed version of Keras is Keras 3, but this is not yet supported in Transformers. Please install the backwards-compatible tf-keras package with `pip install tf-keras`."

I got this error with a fresh Ubuntu image and walking through the [Max setup steps](https://docs.modular.com/engine/get-started).  So I think this would happen to anyone getting latest TensorFlow and latest Transformers.

update: TensorFlow 2.16 [released March 13](https://blog.tensorflow.org/2024/03/whats-new-in-tensorflow-216.html) made the switch to Keras 3.